### PR TITLE
feature: use bound action rather than a service action

### DIFF
--- a/bookshop/srv/cat-service.cds
+++ b/bookshop/srv/cat-service.cds
@@ -1,10 +1,12 @@
 using {codejam} from '../db/schema';
 
 service CatalogService {
-    entity Books   as projection on codejam.Books;
+    entity Books   as projection on codejam.Books
+        actions {
+            action submitOrder(quantity : Integer) returns {
+                stock : Integer
+            };
+        };
     entity Authors as projection on codejam.Authors;
 
-    action submitOrder(book : Books:ID, quantity : Integer) returns {
-        stock : Integer
-    };
 }

--- a/bookshop/srv/cat-service.js
+++ b/bookshop/srv/cat-service.js
@@ -4,8 +4,11 @@ module.exports = function() {
 	const { Books } = cds.entities('codejam')
 
 	// Reduce stock of ordered books if available stock suffices
-	this.on('submitOrder', async req => {
-		const { book, quantity } = req.data
+	this.on('submitOrder', 'Books', async (req) => {
+		// TODO: is there a better way to get ID of the book, on which the action was executed?
+		const book = req.query.SELECT.from.ref[0].where[2].val;
+
+		const { quantity } = req.data
 		if (quantity < 1) return req.reject(400, `quantity has to be 1 or more`)
 		let b = await SELECT`stock`.from(Books, book)
 		if (!b) return req.error(404, `Book #${book} doesn't exist`)

--- a/chapters/04-handler/readme.md
+++ b/chapters/04-handler/readme.md
@@ -74,8 +74,7 @@ sap.ui.define([
             const selectedBookID = oContext.getProperty("ID")
             const selectedQuantity = this.byId("stepInput").getValue()
 
-            const oAction = oModel.bindContext("/submitOrder(...)")
-            oAction.setParameter("book", selectedBookID)
+            const oAction = oModel.bindContext("CatalogService.submitOrder(...)", oContext);
             oAction.setParameter("quantity", selectedQuantity)
 
             oAction.execute().then(


### PR DESCRIPTION
Hi @nicoschoenteich 

here is a PR where the action has been made an entity-bound action.

obviously, the action needs to be used differently within UI5 (respective document section as been adjusted as well)